### PR TITLE
feat(US-8): Show admin sessions

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -9,6 +9,7 @@ import { loadBookingRoutes } from "./src/Booking/routes.js";
 import { loadCinemaRoutes } from "./src/Cinema/routes.js";
 import { loadGenreRoutes } from "./src/Genre/routes.js";
 import { loadMovieRoutes } from "./src/Movie/routes.js";
+import { loadQualityRoutes } from "./src/Quality/routes.js";
 import { loadSessionRoutes } from "./src/Session/routes.js";
 import AuthJwtRepository from "./src/User/Adapter/Jwt/AuthJwtRepository.js";
 import GetMeRepository from "./src/User/Adapter/Sequelize/GetMe/GetMeRepository.js";
@@ -95,6 +96,7 @@ import { loadUserRoutes } from "./src/User/routes.js";
 	loadMovieRoutes(app);
 	loadSessionRoutes(app);
 	loadUserRoutes(app);
+	loadQualityRoutes(app);
 
 	app.listen(port, () => {
 		console.log(`Server is running on http://localhost:${port}`);

--- a/backend/src/Cinema/Adapter/Http/GetCinemaRooms/GetCinemaRoomsController.js
+++ b/backend/src/Cinema/Adapter/Http/GetCinemaRooms/GetCinemaRoomsController.js
@@ -1,0 +1,9 @@
+export default class GetCinemaRoomsController {
+	constructor(validator, service) {
+		this.service = service;
+	}
+
+	async handle(request) {
+		return await this.service.execute(request);
+	}
+}

--- a/backend/src/Cinema/Adapter/Sequelize/CinemaModel.js
+++ b/backend/src/Cinema/Adapter/Sequelize/CinemaModel.js
@@ -1,8 +1,9 @@
 import { DataTypes } from "@sequelize/core";
 
 import { SequelizeFactory } from "../../../Common/Utils/sequelize.js";
+import CinemaRoomModel from "./CinemaRoomModel.js";
 
-export default SequelizeFactory.getInstance()
+const model = SequelizeFactory.getInstance()
 	.getSequelize()
 	.define(
 		"cinema",
@@ -31,3 +32,7 @@ export default SequelizeFactory.getInstance()
 			paranoid: true,
 		}
 	);
+
+model.hasMany(CinemaRoomModel, { foreignKey: "cinemaId" });
+
+export default model;

--- a/backend/src/Cinema/Adapter/Sequelize/CinemaRoomModel.js
+++ b/backend/src/Cinema/Adapter/Sequelize/CinemaRoomModel.js
@@ -1,0 +1,30 @@
+import { DataTypes } from "@sequelize/core";
+
+import { SequelizeFactory } from "../../../Common/Utils/sequelize.js";
+
+export default SequelizeFactory.getInstance()
+	.getSequelize()
+	.define(
+		"cinemas_rooms",
+		{
+			cinemaRoomId: {
+				primaryKey: true,
+				type: DataTypes.UUID,
+			},
+			cinemaId: {
+				type: DataTypes.UUID,
+			},
+			qualityId: {
+				type: DataTypes.STRING,
+			},
+			roomNumber: {
+				type: DataTypes.INTEGER,
+			},
+			placementsMatrix: {
+				type: DataTypes.STRING,
+			},
+		},
+		{
+			paranoid: true,
+		}
+	);

--- a/backend/src/Cinema/Adapter/Sequelize/GetCinemaRooms/GetCinemaRoomsRepository.js
+++ b/backend/src/Cinema/Adapter/Sequelize/GetCinemaRooms/GetCinemaRoomsRepository.js
@@ -1,0 +1,52 @@
+import { Op } from "sequelize";
+
+import Cinema from "../../../Business/Cinema.js";
+import CinemaRoom from "../../../Business/CinemaRoom.js";
+import Quality from "../../../Business/Quality.js";
+import CinemaModel from "../CinemaModel.js";
+import CinemaRoomModel from "../CinemaRoomModel.js";
+import QualityModel from "../QualityModel.js";
+
+export default class GetCinemaRoomsRepository {
+	async fetchAll({ cinemaId = null, limit }) {
+		const query = {
+			include: [
+				{
+					model: CinemaModel,
+					required: true,
+				},
+				{
+					model: QualityModel,
+					required: true,
+				},
+			],
+			where: {},
+			order: [["roomNumber", "ASC"]],
+			limit,
+		};
+		if (cinemaId) {
+			query.where.cinemaId = { [Op.eq]: cinemaId };
+		}
+		const cinemaRooms = await CinemaRoomModel.findAll(query);
+
+		return cinemaRooms.map((cinemaRoom) => {
+			const obj = new CinemaRoom();
+			obj.setCinemaRoomId(cinemaRoom.cinemaRoomId);
+			obj.setRoomNumber(cinemaRoom.roomNumber);
+			obj.setPlacementsMatrix(cinemaRoom.placementsMatrix);
+
+			const c = new Cinema();
+			c.setCinemaId(cinemaRoom.cinema.cinemaId);
+			c.setCountryCode(cinemaRoom.cinema.countryCode);
+			c.setCinemaName(cinemaRoom.cinema.cinemaName);
+			obj.setCinema(c);
+
+			const q = new Quality();
+			q.setQualityId(cinemaRoom.qualities.qualityId);
+			q.setQualityName(cinemaRoom.qualities.qualityName);
+			obj.setCinema(q);
+
+			return obj;
+		});
+	}
+}

--- a/backend/src/Cinema/Adapter/Sequelize/QualityModel.js
+++ b/backend/src/Cinema/Adapter/Sequelize/QualityModel.js
@@ -1,0 +1,22 @@
+import { DataTypes } from "@sequelize/core";
+import CinemaRoomModel from "./CinemaRoomModel.js";
+
+import { SequelizeFactory } from "../../../Common/Utils/sequelize.js";
+
+const model = SequelizeFactory.getInstance()
+	.getSequelize()
+	.define("qualities", {
+		qualityId: {
+			primaryKey: true,
+			type: DataTypes.UUID,
+		},
+		qualityName: {
+			type: DataTypes.STRING,
+		},
+	}, {
+		paranoid: true
+	});
+
+model.hasMany(CinemaRoomModel, { foreignKey: "qualityId" });
+
+export default model;

--- a/backend/src/Cinema/Business/CinemaRoom.js
+++ b/backend/src/Cinema/Business/CinemaRoom.js
@@ -1,0 +1,21 @@
+export default class CinemaRoom {
+	setCinemaRoomId(cinemaRoomId) {
+		this.cinemaRoomId = cinemaRoomId;
+	}
+
+	setRoomNumber(roomNumber) {
+		this.roomNumber = roomNumber;
+	}
+
+	setPlacementsMatrix(placementsMatrix) {
+		this.placementsMatrix = placementsMatrix;
+	}
+
+	setCinema(cinema) {
+		Object.assign(this, cinema);
+	}
+
+	setQuality(quality) {
+		Object.assign(this, quality);
+	}
+}

--- a/backend/src/Cinema/Business/Quality.js
+++ b/backend/src/Cinema/Business/Quality.js
@@ -1,0 +1,9 @@
+export default class Quality {
+	setQualityId(qualityId) {
+		this.qualityId = qualityId;
+	}
+
+	setQualityName(qualityName) {
+		this.qualityName = qualityName;
+	}
+}

--- a/backend/src/Cinema/UseCase/GetCinemaRooms/GetCinemaRoomsService.js
+++ b/backend/src/Cinema/UseCase/GetCinemaRooms/GetCinemaRoomsService.js
@@ -1,0 +1,15 @@
+import Response from "../../../Common/Utils/Response.js";
+
+export const LIMIT = 500;
+
+export default class GetCinemasRooms {
+	constructor(repository) {
+		this.repository = repository;
+	}
+
+	async execute(query) {
+		const res = new Response();
+		res.setData(await this.repository.fetchAll({ ...query, limit: LIMIT }));
+		return res;
+	}
+}

--- a/backend/src/Cinema/routes.js
+++ b/backend/src/Cinema/routes.js
@@ -1,8 +1,11 @@
 import GetGeoJsClosestCinemaRepository from "./Adapter/GeoJs/GetClosestCinema/GetClosestCinemaRepository.js";
+import GetCinemaRoomsController from "./Adapter/Http/GetCinemaRooms/GetCinemaRoomsController.js";
 import GetCinemasController from "./Adapter/Http/GetCinemas/GetCinemasController.js";
 import GetClosestCinemaController from "./Adapter/Http/GetClosestCinema/GetClosestCinemaController.js";
+import GetCinemaRoomsRepository from "./Adapter/Sequelize/GetCinemaRooms/GetCinemaRoomsRepository.js";
 import GetCinemasRepository from "./Adapter/Sequelize/GetCinemas/GetCinemasRepository.js";
 import GetSequelizeClosestCinemaRepository from "./Adapter/Sequelize/GetClosestCinema/GetClosestCinemaRepository.js";
+import GetCinemaRoomsService from "./UseCase/GetCinemaRooms/GetCinemaRoomsService.js";
 import GetCinemasService from "./UseCase/GetCinemas/GetCinemasService.js";
 import GetClosestCinemaService from "./UseCase/GetClosestCinema/GetClosestCinemaService.js";
 
@@ -27,6 +30,23 @@ export const loadCinemaRoutes = (app) => {
 			const response = await controller.handle({
 				// IP of the client (Production) or null (localhost)
 				remoteAddr: req.headers["x-forwarded-for"] || null,
+			});
+			res.status(200).json(response);
+		} catch (err) {
+			console.error(err);
+			res.status(500).json({ error: true });
+		}
+	});
+
+	app.get("/api/v1/cinemas/:cinemaId/rooms", async (req, res) => {
+		try {
+			if (!req.me || !["admin", "employee"].includes(req.me.role)) {
+				return res.status(401).json({ error: true });
+			}
+
+			const controller = new GetCinemaRoomsController(null, new GetCinemaRoomsService(new GetCinemaRoomsRepository()));
+			const response = await controller.handle({
+				cinemaId: req.params.cinemaId,
 			});
 			res.status(200).json(response);
 		} catch (err) {

--- a/backend/src/Quality/Adapter/Http/GetQualities/GetQualitiesController.js
+++ b/backend/src/Quality/Adapter/Http/GetQualities/GetQualitiesController.js
@@ -1,0 +1,9 @@
+export default class GetQualitiesController {
+	constructor(validator, service) {
+		this.service = service;
+	}
+
+	async handle(request) {
+		return await this.service.execute(request);
+	}
+}

--- a/backend/src/Quality/Adapter/Sequelize/GetQualities/GetQualitiesRepository.js
+++ b/backend/src/Quality/Adapter/Sequelize/GetQualities/GetQualitiesRepository.js
@@ -1,0 +1,18 @@
+import Quality from "../../../Business/Quality.js";
+import QualityModel from "../QualityModel.js";
+
+export default class GetQualitiesRepository {
+	async fetchAll({ limit }) {
+		const qualities = await QualityModel.findAll({
+			order: [["qualityName", "ASC"]],
+			limit,
+		});
+
+		return qualities.map((quality) => {
+			const obj = new Quality();
+			obj.setQualityId(quality.qualityId);
+			obj.setQualityName(quality.qualityName);
+			return obj;
+		});
+	}
+}

--- a/backend/src/Quality/Adapter/Sequelize/QualityModel.js
+++ b/backend/src/Quality/Adapter/Sequelize/QualityModel.js
@@ -1,0 +1,21 @@
+import { DataTypes } from "@sequelize/core";
+
+import { SequelizeFactory } from "../../../Common/Utils/sequelize.js";
+
+export default SequelizeFactory.getInstance()
+	.getSequelize()
+	.define(
+		"quality",
+		{
+			qualityId: {
+				primaryKey: true,
+				type: DataTypes.UUID,
+			},
+			qualityName: {
+				type: DataTypes.STRING,
+			},
+		},
+		{
+			paranoid: true,
+		}
+	);

--- a/backend/src/Quality/Business/Quality.js
+++ b/backend/src/Quality/Business/Quality.js
@@ -1,0 +1,9 @@
+export default class Quality {
+	setQualityId(qualityId) {
+		this.qualityId = qualityId;
+	}
+
+	setQualityName(qualityName) {
+		this.qualityName = qualityName;
+	}
+}

--- a/backend/src/Quality/UseCase/GetQualities/GetQualitiesService.js
+++ b/backend/src/Quality/UseCase/GetQualities/GetQualitiesService.js
@@ -1,0 +1,15 @@
+import Response from "../../../Common/Utils/Response.js";
+
+export const LIMIT = 500;
+
+export default class GetQualitiesService {
+	constructor(repository) {
+		this.repository = repository;
+	}
+
+	async execute() {
+		const response = new Response();
+		response.setData(await this.repository.fetchAll({ limit: LIMIT }));
+		return response;
+	}
+}

--- a/backend/src/Quality/routes.js
+++ b/backend/src/Quality/routes.js
@@ -1,0 +1,16 @@
+import GetQualitiesController from "./Adapter/Http/GetQualities/GetQualitiesController.js";
+import GetQualitiesRepository from "./Adapter/Sequelize/GetQualities/GetQualitiesRepository.js";
+import GetQualitiesService from "./UseCase/GetQualities/GetQualitiesService.js";
+
+export const loadQualityRoutes = (app) => {
+	app.get("/api/v1/qualities", async (req, res) => {
+		try {
+			const controller = new GetQualitiesController(null, new GetQualitiesService(new GetQualitiesRepository()));
+			const response = await controller.handle();
+			res.status(200).json(response);
+		} catch (err) {
+			console.error(err);
+			res.status(500).json({ error: true });
+		}
+	});
+};

--- a/backend/src/Session/Adapter/Http/CreateSession/CreateSessionController.js
+++ b/backend/src/Session/Adapter/Http/CreateSession/CreateSessionController.js
@@ -1,0 +1,10 @@
+export default class CreateSessionController {
+	constructor(validator, service) {
+		this.service = service;
+	}
+
+	async handle(request) {
+		// Delegate request validation to the service
+		return await this.service.execute(request);
+	}
+}

--- a/backend/src/Session/Adapter/Http/DeleteSession/DeleteSessionController.js
+++ b/backend/src/Session/Adapter/Http/DeleteSession/DeleteSessionController.js
@@ -1,0 +1,10 @@
+export default class DeleteSessionController {
+	constructor(validator, service) {
+		this.service = service;
+	}
+
+	async handle(request) {
+		// Delegate request validation to the service
+		return await this.service.execute(request);
+	}
+}

--- a/backend/src/Session/Adapter/Http/UpdateSession/UpdateSessionController.js
+++ b/backend/src/Session/Adapter/Http/UpdateSession/UpdateSessionController.js
@@ -1,0 +1,10 @@
+export default class UpdateSessionController {
+	constructor(validator, service) {
+		this.service = service;
+	}
+
+	async handle(request) {
+		// Delegate request validation to the service
+		return await this.service.execute(request);
+	}
+}

--- a/backend/src/Session/Adapter/Sequelize/CreateSession/CreateSessionRepository.js
+++ b/backend/src/Session/Adapter/Sequelize/CreateSession/CreateSessionRepository.js
@@ -1,0 +1,18 @@
+import SessionModel from "../SessionModel.js";
+
+export default class CreateSessionRepository {
+	async create({ sessionId, cinemaId, movieId, cinemaRoomId, qualityId, startDate, endDate, standartFreePlaces, disabledFreePlaces }) {
+		await SessionModel.create({
+			sessionId,
+			cinemaId,
+			movieId,
+			cinemaRoomId,
+			qualityId,
+			startDate,
+			endDate,
+			standartFreePlaces,
+			disabledFreePlaces,
+		});
+		return true;
+	}
+}

--- a/backend/src/Session/Adapter/Sequelize/DeleteSession/DeleteSessionRepository.js
+++ b/backend/src/Session/Adapter/Sequelize/DeleteSession/DeleteSessionRepository.js
@@ -1,0 +1,24 @@
+import { Op } from "sequelize";
+
+import SessionModel from "../SessionModel.js";
+
+export default class DeleteSessionRepository {
+	async exists({ sessionId }) {
+		const query = {
+			where: {},
+		};
+		if (sessionId) {
+			query.where.sessionId = { [Op.eq]: sessionId };
+		}
+		return !!(await SessionModel.findOne(query));
+	}
+
+	async destroy({ sessionId }) {
+		await SessionModel.destroy({
+			where: {
+				sessionId: { [Op.eq]: sessionId },
+			},
+		});
+		return true;
+	}
+}

--- a/backend/src/Session/Adapter/Sequelize/GetSessions/GetSessionsRepository.js
+++ b/backend/src/Session/Adapter/Sequelize/GetSessions/GetSessionsRepository.js
@@ -103,6 +103,9 @@ export default class GetSessionsRepository {
 				obj.setEndDate(session.endDate);
 				obj.setStandartFreePlaces(session.standartFreePlaces);
 				obj.setDisabledFreePlaces(session.disabledFreePlaces);
+				obj.setCreatedAt(session.createdAt);
+				obj.setUpdatedAt(session.updatedAt);
+
 				return obj;
 			}),
 		};

--- a/backend/src/Session/Adapter/Sequelize/UpdateSession/UpdateSessionRepository.js
+++ b/backend/src/Session/Adapter/Sequelize/UpdateSession/UpdateSessionRepository.js
@@ -1,0 +1,36 @@
+import { Op } from "sequelize";
+
+import SessionModel from "../SessionModel.js";
+
+export default class UpdateSessionRepository {
+	async exists({ sessionId }) {
+		const query = {
+			where: {},
+		};
+		if (sessionId) {
+			query.where.sessionId = { [Op.eq]: sessionId };
+		}
+		return !!(await SessionModel.findOne(query));
+	}
+
+	async update({ sessionId, cinemaId, movieId, cinemaRoomId, qualityId, startDate, endDate, standartFreePlaces, disabledFreePlaces }) {
+		await SessionModel.update(
+			{
+				cinemaId,
+				movieId,
+				cinemaRoomId,
+				qualityId,
+				startDate,
+				endDate,
+				standartFreePlaces,
+				disabledFreePlaces,
+			},
+			{
+				where: {
+					sessionId: { [Op.eq]: sessionId },
+				},
+			}
+		);
+		return true;
+	}
+}

--- a/backend/src/Session/Business/Session.js
+++ b/backend/src/Session/Business/Session.js
@@ -58,4 +58,12 @@ export default class Session {
 	setSessionReservedPlacement(sessionReservedPlacement) {
 		Object.assign(this, sessionReservedPlacement);
 	}
+
+	setCreatedAt(createdAt) {
+		this.createdAt = createdAt;
+	}
+
+	setUpdatedAt(updatedAt) {
+		this.updatedAt = updatedAt;
+	}
 }

--- a/backend/src/Session/UseCase/CreateSession/CreateSessionService.js
+++ b/backend/src/Session/UseCase/CreateSession/CreateSessionService.js
@@ -1,0 +1,75 @@
+import crypto from "crypto";
+
+import Response from "../../../Common/Utils/Response.js";
+import { SequelizeFactory } from "../../../Common/Utils/sequelize.js";
+import Session from "../../Business/Session.js";
+
+export default class CreateSessionService {
+	constructor(repository) {
+		this.repository = repository;
+	}
+
+	async execute(query) {
+		const res = new Response();
+		const errors = [];
+
+		// We verify again: don't trust the user's inputs
+		if (!query.movieId) {
+			errors.push("INVALID_MOVIE_ID");
+		}
+		if (!query.cinemaId) {
+			errors.push("INVALID_CINEMA_ID");
+		}
+		if (!query.cinemaRoomId) {
+			errors.push("INVALID_CINEMA_ROOM_ID");
+		}
+		if (!query.qualityId) {
+			errors.push("INVALID_QUALITY_ID");
+		}
+		if (!query.startDate) {
+			errors.push("INVALID_START_DATE");
+		}
+		if (!query.endDate) {
+			errors.push("INVALID_END_DATE");
+		}
+		if (parseInt(query.standartFreePlaces, 10) < 0) {
+			errors.push("INVALID_STANDART_FREE_PLACES");
+		}
+		if (parseInt(query.disabledFreePlaces, 10) < 0) {
+			errors.push("INVALID_DISABLED_FREE_PLACES");
+		}
+
+		if (errors.length) {
+			res.setStatus("USER_ERRORS");
+			res.setErrors(errors);
+			return res;
+		}
+
+		// It's enough random that duplicates are "near impossible"
+		const sessionId = crypto.randomUUID();
+
+		// Use managed transactions by Sequelize
+		// The transaction will be automatically commited on success or rollbacked on error
+		await SequelizeFactory.getInstance()
+			.getSequelize()
+			.transaction(async () => {
+				await this.repository.create({
+					sessionId,
+					cinemaId: query.cinemaId,
+					movieId: query.movieId,
+					cinemaRoomId: query.cinemaRoomId,
+					qualityId: query.qualityId,
+					startDate: query.startDate,
+					endDate: query.endDate,
+					standartFreePlaces: parseInt(query.standartFreePlaces, 10),
+					disabledFreePlaces: parseInt(query.disabledFreePlaces, 10),
+				});
+
+				const session = new Session();
+				session.setSessionId(sessionId);
+				res.setData(session);
+			});
+
+		return res;
+	}
+}

--- a/backend/src/Session/UseCase/DeleteSession/DeleteSessionService.js
+++ b/backend/src/Session/UseCase/DeleteSession/DeleteSessionService.js
@@ -1,0 +1,44 @@
+import Response from "../../../Common/Utils/Response.js";
+import { SequelizeFactory } from "../../../Common/Utils/sequelize.js";
+import Session from "../../Business/Session.js";
+
+export default class DeleteSessionService {
+	constructor(repository) {
+		this.repository = repository;
+	}
+
+	async execute(query) {
+		const res = new Response();
+		const errors = [];
+
+		// We verify again: don't trust the user's inputs
+		if (!query.sessionId) {
+			errors.push("INVALID_SESSION_ID");
+		}
+		if (!(await this.repository.exists({ sessionId: query.sessionId }))) {
+			errors.push("UNKNOWN_SESSION_ID");
+		}
+
+		if (errors.length) {
+			res.setStatus("USER_ERRORS");
+			res.setErrors(errors);
+			return res;
+		}
+
+		// Use managed transactions by Sequelize
+		// The transaction will be automatically commited on success or rollbacked on error
+		await SequelizeFactory.getInstance()
+			.getSequelize()
+			.transaction(async () => {
+				await this.repository.destroy({
+					sessionId: query.sessionId,
+				});
+
+				const session = new Session();
+				session.setSessionId(query.sessionId);
+				res.setData(session);
+			});
+
+		return res;
+	}
+}

--- a/backend/src/Session/UseCase/UpdateSession/UpdateSessionService.js
+++ b/backend/src/Session/UseCase/UpdateSession/UpdateSessionService.js
@@ -1,0 +1,72 @@
+import Response from "../../../Common/Utils/Response.js";
+import { SequelizeFactory } from "../../../Common/Utils/sequelize.js";
+import Session from "../../Business/Session.js";
+
+export default class UpdateSessionService {
+	constructor(repository) {
+		this.repository = repository;
+	}
+
+	async execute(query) {
+		const res = new Response();
+		const errors = [];
+
+		// We verify again: don't trust the user's inputs
+		if (!query.sessionId) {
+			errors.push("INVALID_SESSION_ID");
+		}
+		if (!query.cinemaId) {
+			errors.push("INVALID_CINEMA_ID");
+		}
+		if (!query.movieId) {
+			errors.push("INVALID_MOVIE_ID");
+		}
+		if (!query.cinemaRoomId) {
+			errors.push("INVALID_CINEMA_ROOM_ID");
+		}
+		if (!query.qualityId) {
+			errors.push("INVALID_QUALITY_ID");
+		}
+		if (!query.startDate) {
+			errors.push("INVALID_START_DATE");
+		}
+		if (!query.endDate) {
+			errors.push("INVALID_END_DATE");
+		}
+		if (parseInt(query.standartFreePlaces, 10) < 0) {
+			errors.push("INVALID_STANDART_FREE_PLACES");
+		}
+		if (parseInt(query.disabledFreePlaces, 10) < 0) {
+			errors.push("INVALID_DISABLED_FREE_PLACES");
+		}
+
+		if (errors.length) {
+			res.setStatus("USER_ERRORS");
+			res.setErrors(errors);
+			return res;
+		}
+
+		// Use managed transactions by Sequelize
+		// The transaction will be automatically commited on success or rollbacked on error
+		await SequelizeFactory.getInstance()
+			.getSequelize()
+			.transaction(async () => {
+				await this.repository.update({
+					sessionId: query.sessionId,
+					cinemaId: query.cinemaId,
+					movieId: query.movieId,
+					cinemaRoomId: query.cinemaRoomId,
+					qualityId: query.qualityId,
+					startDate: query.startDate,
+					endDate: query.endDate,
+					standartFreePlaces: parseInt(query.standartFreePlaces, 10),
+					disabledFreePlaces: parseInt(query.disabledFreePlaces, 10),
+				});
+				const session = new Session();
+				session.setSessionId(query.sessionId);
+				res.setData(session);
+			});
+
+		return res;
+	}
+}

--- a/backend/src/Session/routes.js
+++ b/backend/src/Session/routes.js
@@ -1,8 +1,10 @@
 import CreateSessionController from "./Adapter/Http/CreateSession/CreateSessionController.js";
+import DeleteSessionController from "./Adapter/Http/DeleteSession/DeleteSessionController.js";
 import GetSessionController from "./Adapter/Http/GetSession/GetSessionController.js";
 import GetSessionsController from "./Adapter/Http/GetSessions/GetSessionsController.js";
 import UpdateSessionController from "./Adapter/Http/UpdateSession/UpdateSessionController.js";
 import CreateSessionRepository from "./Adapter/Sequelize/CreateSession/CreateSessionRepository.js";
+import DeleteSessionRepository from "./Adapter/Sequelize/DeleteSession/DeleteSessionRepository.js";
 import GetSessionRepository from "./Adapter/Sequelize/GetSession/GetSessionRepository.js";
 import GetSessionReservedPlacementRepository from "./Adapter/Sequelize/GetSession/GetSessionReservedPlacementRepository.js";
 import GetSessionsCinemasRepository from "./Adapter/Sequelize/GetSessions/GetSessionsCinemasRepository.js";
@@ -10,6 +12,7 @@ import GetSessionsPricesRepository from "./Adapter/Sequelize/GetSessions/GetSess
 import GetSessionsRepository from "./Adapter/Sequelize/GetSessions/GetSessionsRepository.js";
 import UpdateSessionRepository from "./Adapter/Sequelize/UpdateSession/UpdateSessionRepository.js";
 import CreateSessionService from "./UseCase/CreateSession/CreateSessionService.js";
+import DeleteSessionService from "./UseCase/DeleteSession/DeleteSessionService.js";
 import GetSessionService from "./UseCase/GetSession/GetSessionService.js";
 import GetSessionsService from "./UseCase/GetSessions/GetSessionsService.js";
 import UpdateSessionService from "./UseCase/UpdateSession/UpdateSessionService.js";
@@ -76,6 +79,29 @@ export const loadSessionRoutes = (app) => {
 			const response = await controller.handle(req.body);
 
 			let code = 201; // Created
+			if (response.status === "USER_ERRORS") {
+				code = 400; // Bad request
+			}
+
+			res.status(code).json(response);
+		} catch (err) {
+			console.error(err);
+			res.status(500).json({ error: true });
+		}
+	});
+
+	app.delete("/api/v1/sessions/:sessionId", async (req, res) => {
+		try {
+			if (!req.me || !["admin", "employee"].includes(req.me.role)) {
+				return res.status(401).json({ error: true });
+			}
+
+			const controller = new DeleteSessionController(null, new DeleteSessionService(new DeleteSessionRepository()));
+			const response = await controller.handle({
+				sessionId: req.params.sessionId,
+			});
+
+			let code = 204; // No content
 			if (response.status === "USER_ERRORS") {
 				code = 400; // Bad request
 			}

--- a/backend/src/Session/routes.js
+++ b/backend/src/Session/routes.js
@@ -1,12 +1,15 @@
+import CreateSessionController from "./Adapter/Http/CreateSession/CreateSessionController.js";
 import GetSessionController from "./Adapter/Http/GetSession/GetSessionController.js";
 import GetSessionsController from "./Adapter/Http/GetSessions/GetSessionsController.js";
 import UpdateSessionController from "./Adapter/Http/UpdateSession/UpdateSessionController.js";
+import CreateSessionRepository from "./Adapter/Sequelize/CreateSession/CreateSessionRepository.js";
 import GetSessionRepository from "./Adapter/Sequelize/GetSession/GetSessionRepository.js";
 import GetSessionReservedPlacementRepository from "./Adapter/Sequelize/GetSession/GetSessionReservedPlacementRepository.js";
 import GetSessionsCinemasRepository from "./Adapter/Sequelize/GetSessions/GetSessionsCinemasRepository.js";
 import GetSessionsPricesRepository from "./Adapter/Sequelize/GetSessions/GetSessionsPricesRepository.js";
 import GetSessionsRepository from "./Adapter/Sequelize/GetSessions/GetSessionsRepository.js";
 import UpdateSessionRepository from "./Adapter/Sequelize/UpdateSession/UpdateSessionRepository.js";
+import CreateSessionService from "./UseCase/CreateSession/CreateSessionService.js";
 import GetSessionService from "./UseCase/GetSession/GetSessionService.js";
 import GetSessionsService from "./UseCase/GetSessions/GetSessionsService.js";
 import UpdateSessionService from "./UseCase/UpdateSession/UpdateSessionService.js";
@@ -52,6 +55,27 @@ export const loadSessionRoutes = (app) => {
 			const response = await controller.handle({ ...req.body, sessionId: req.params.sessionId });
 
 			let code = 204; // No content
+			if (response.status === "USER_ERRORS") {
+				code = 400; // Bad request
+			}
+
+			res.status(code).json(response);
+		} catch (err) {
+			console.error(err);
+			res.status(500).json({ error: true });
+		}
+	});
+
+	app.post("/api/v1/sessions", async (req, res) => {
+		try {
+			if (!req.me || !["admin", "employee"].includes(req.me.role)) {
+				return res.status(401).json({ error: true });
+			}
+
+			const controller = new CreateSessionController(null, new CreateSessionService(new CreateSessionRepository()));
+			const response = await controller.handle(req.body);
+
+			let code = 201; // Created
 			if (response.status === "USER_ERRORS") {
 				code = 400; // Bad request
 			}

--- a/backend/src/Session/routes.js
+++ b/backend/src/Session/routes.js
@@ -1,12 +1,15 @@
 import GetSessionController from "./Adapter/Http/GetSession/GetSessionController.js";
 import GetSessionsController from "./Adapter/Http/GetSessions/GetSessionsController.js";
+import UpdateSessionController from "./Adapter/Http/UpdateSession/UpdateSessionController.js";
 import GetSessionRepository from "./Adapter/Sequelize/GetSession/GetSessionRepository.js";
 import GetSessionReservedPlacementRepository from "./Adapter/Sequelize/GetSession/GetSessionReservedPlacementRepository.js";
 import GetSessionsCinemasRepository from "./Adapter/Sequelize/GetSessions/GetSessionsCinemasRepository.js";
 import GetSessionsPricesRepository from "./Adapter/Sequelize/GetSessions/GetSessionsPricesRepository.js";
 import GetSessionsRepository from "./Adapter/Sequelize/GetSessions/GetSessionsRepository.js";
+import UpdateSessionRepository from "./Adapter/Sequelize/UpdateSession/UpdateSessionRepository.js";
 import GetSessionService from "./UseCase/GetSession/GetSessionService.js";
 import GetSessionsService from "./UseCase/GetSessions/GetSessionsService.js";
+import UpdateSessionService from "./UseCase/UpdateSession/UpdateSessionService.js";
 
 export const loadSessionRoutes = (app) => {
 	app.get("/api/v1/sessions", async (req, res) => {
@@ -33,6 +36,27 @@ export const loadSessionRoutes = (app) => {
 				sessionId: req.params.sessionId,
 			});
 			res.status(200).json(response);
+		} catch (err) {
+			console.error(err);
+			res.status(500).json({ error: true });
+		}
+	});
+
+	app.put("/api/v1/sessions/:sessionId", async (req, res) => {
+		try {
+			if (!req.me || !["admin", "employee"].includes(req.me.role)) {
+				return res.status(401).json({ error: true });
+			}
+
+			const controller = new UpdateSessionController(null, new UpdateSessionService(new UpdateSessionRepository()));
+			const response = await controller.handle({ ...req.body, sessionId: req.params.sessionId });
+
+			let code = 204; // No content
+			if (response.status === "USER_ERRORS") {
+				code = 400; // Bad request
+			}
+
+			res.status(code).json(response);
 		} catch (err) {
 			console.error(err);
 			res.status(500).json({ error: true });

--- a/website/src/components/molecules/Pagination/Pagination.jsx
+++ b/website/src/components/molecules/Pagination/Pagination.jsx
@@ -2,16 +2,18 @@ import TablePagination from "@mui/material/TablePagination";
 import { useState } from "react";
 
 export default function Pagination({ pagination, onChange }) {
-	const [page, setPage] = useState(pagination.currentPage);
+	const [page, setPage] = useState(pagination.currentPage - 1);
 	const [rowsPerPage, setRowsPerPage] = useState(pagination.perPage);
 
 	const handleChangePage = (event, newPage) => {
-		onChange(newPage);
+		setPage(newPage);
+		onChange(newPage + 1);
 	};
 
 	const handleChangeRowsPerPage = (event) => {
 		setRowsPerPage(parseInt(event.target.value, 10));
 		setPage(0);
+		handleChangePage();
 	};
 
 	return (

--- a/website/src/components/organisms/AdminSessionList/AdminSessionList.jsx
+++ b/website/src/components/organisms/AdminSessionList/AdminSessionList.jsx
@@ -1,0 +1,183 @@
+import Button from "@mui/material/Button";
+import Paper from "@mui/material/Paper";
+import Table from "@mui/material/Table";
+import TableBody from "@mui/material/TableBody";
+import TableCell, { tableCellClasses } from "@mui/material/TableCell";
+import TableContainer from "@mui/material/TableContainer";
+import TableHead from "@mui/material/TableHead";
+import TableRow from "@mui/material/TableRow";
+import { styled } from "@mui/material/styles";
+import axios from "axios";
+import moment from "moment";
+import { useSnackbar } from "notistack";
+import { useEffect, useState } from "react";
+import { useMutation, useQuery } from "react-query";
+
+import { Pagination } from "components/molecules/Pagination";
+import { AdminSessionModal } from "components/organisms/AdminSessionModal";
+
+const StyledTableCell = styled(TableCell)(({ theme }) => ({
+	[`&.${tableCellClasses.head}`]: {
+		backgroundColor: theme.palette.common.black,
+		color: theme.palette.common.white,
+	},
+	[`&.${tableCellClasses.body}`]: {
+		fontSize: 14,
+	},
+}));
+
+const StyledTableRow = styled(TableRow)(({ theme }) => ({
+	"&:nth-of-type(odd)": {
+		backgroundColor: theme.palette.action.hover,
+	},
+	// hide last border
+	"&:last-child td, &:last-child th": {
+		border: 0,
+	},
+}));
+
+const retrieveSessions = async ({ currentPage, perPage }) => {
+	const response = await axios.get(`${process.env.REACT_APP_BACKEND_BASE_URL}/api/v1/sessions`, {
+		params: {
+			currentPage,
+			perPage,
+		},
+	});
+	return response.data;
+};
+
+const submitDelete = async ({ sessionId }) => {
+	return await axios.delete(`${process.env.REACT_APP_BACKEND_BASE_URL}/api/v1/sessions/${sessionId}`);
+};
+
+export default function AdminSessionList() {
+	const [currentPage, setCurrentPage] = useState(1);
+	const [adminSessionModalOpened, setAdminSessionModalOpened] = useState(false);
+	const [selectedSession, setSelectedSession] = useState();
+
+	const { enqueueSnackbar } = useSnackbar();
+
+	const {
+		data: sessionsData,
+		error: sessionsError,
+		isLoading: sessionsIsLoading,
+		refetch: sessionsRefetch,
+	} = useQuery("admin-sessions", () => retrieveSessions({ currentPage, perPage: 5 }));
+
+	const deleteSession = useMutation({
+		mutationFn: submitDelete,
+	});
+
+	useEffect(() => {
+		sessionsRefetch();
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [currentPage]);
+
+	if (sessionsIsLoading) {
+		return <div>...</div>;
+	}
+	if (sessionsError) {
+		return <div>Une erreur est survenue</div>;
+	}
+
+	return (
+		<div>
+			<h1>
+				Scéances{" "}
+				<Button
+					variant="contained"
+					onClick={() => {
+						setSelectedSession(null);
+						setAdminSessionModalOpened(true);
+					}}
+				>
+					Ajouter
+				</Button>
+			</h1>
+
+			{!sessionsData?.data?.length ? (
+				<div>Pas de scéance</div>
+			) : (
+				<TableContainer component={Paper}>
+					<Table sx={{ minWidth: 650 }} aria-label="simple table">
+						<TableHead>
+							<TableRow>
+								<StyledTableCell>Date de début</StyledTableCell>
+								<StyledTableCell>Date de fin</StyledTableCell>
+								<StyledTableCell>Nom du cinéma</StyledTableCell>
+								<StyledTableCell>Numéro de salle</StyledTableCell>
+								<StyledTableCell>Titre du film</StyledTableCell>
+								<StyledTableCell>Qualité</StyledTableCell>
+								<StyledTableCell>Crée le</StyledTableCell>
+								<StyledTableCell>Modifié le</StyledTableCell>
+								<StyledTableCell>Actions</StyledTableCell>
+							</TableRow>
+						</TableHead>
+						<TableBody>
+							{sessionsData.data.map((session) => (
+								<StyledTableRow key={session.sessionsId} sx={{ "&:last-child td, &:last-child th": { border: 0 } }}>
+									<StyledTableCell component="th" scope="row">
+										{moment(session.startDate).format("L HH:mm:ss")}
+									</StyledTableCell>
+									<StyledTableCell>{moment(session.endDate).format("L HH:mm:ss")}</StyledTableCell>
+									<StyledTableCell>{session.cinemaName}</StyledTableCell>
+									<StyledTableCell>{session.roomNumber}</StyledTableCell>
+									<StyledTableCell>{session.title}</StyledTableCell>
+									<StyledTableCell>{session.qualityName}</StyledTableCell>
+									<StyledTableCell>{moment(session.createdAt).format("L")}</StyledTableCell>
+									<StyledTableCell>{session.updatedAt && moment(session.updatedAt).format("L")}</StyledTableCell>
+									<StyledTableCell>
+										<Button
+											variant="contained"
+											size="small"
+											onClick={() => {
+												setSelectedSession(session);
+												setAdminSessionModalOpened(true);
+											}}
+										>
+											Editer
+										</Button>{" "}
+										<Button
+											variant="outlined"
+											size="small"
+											onClick={() => {
+												if (
+													window.confirm(
+														`Êtes-vous sûr de supprimer la scéance du ${moment(session.startDate).format("L HH:mm:ss")} pour le film "${session.title}" ?`
+													)
+												) {
+													deleteSession.mutate(
+														{ sessionId: session.sessionId },
+														{
+															onSuccess: () => {
+																sessionsRefetch();
+																enqueueSnackbar("Scéance supprimée");
+															},
+														}
+													);
+												}
+											}}
+										>
+											Supprimer
+										</Button>
+									</StyledTableCell>
+								</StyledTableRow>
+							))}
+						</TableBody>
+					</Table>
+				</TableContainer>
+			)}
+			{sessionsData?.meta?.pagination && <Pagination pagination={sessionsData?.meta?.pagination} onChange={(pageNumber) => setCurrentPage(pageNumber)} />}
+			{adminSessionModalOpened && (
+				<AdminSessionModal
+					session={selectedSession}
+					onClose={() => {
+						setAdminSessionModalOpened(false);
+						setSelectedSession(null);
+						sessionsRefetch();
+					}}
+				/>
+			)}
+		</div>
+	);
+}

--- a/website/src/components/organisms/AdminSessionList/index.js
+++ b/website/src/components/organisms/AdminSessionList/index.js
@@ -1,0 +1,1 @@
+export { default as AdminSessionList } from "./AdminSessionList";

--- a/website/src/components/organisms/AdminSessionModal/AdminSessionModal.jsx
+++ b/website/src/components/organisms/AdminSessionModal/AdminSessionModal.jsx
@@ -1,0 +1,284 @@
+import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
+import FormControl from "@mui/material/FormControl";
+import InputLabel from "@mui/material/InputLabel";
+import MenuItem from "@mui/material/MenuItem";
+import Select from "@mui/material/Select";
+import TextField from "@mui/material/TextField";
+import axios from "axios";
+import { useEffect } from "react";
+import { useForm } from "react-hook-form";
+import { useMutation, useQuery } from "react-query";
+
+import { Modal } from "components/molecules/Modal";
+
+const DEFAULT_UNKNOWN_ERROR = "Une erreur est survenue, veuillez réessayer";
+
+const retrieveCinemas = async () => {
+	const response = await axios.get(`${process.env.REACT_APP_BACKEND_BASE_URL}/api/v1/cinemas`);
+	return response.data;
+};
+
+const retrieveCinemaRooms = async ({ cinemaId }) => {
+	if (!cinemaId) {
+		return null;
+	}
+	const response = await axios.get(`${process.env.REACT_APP_BACKEND_BASE_URL}/api/v1/cinemas/${encodeURIComponent(cinemaId)}/rooms`);
+	return response.data;
+};
+
+const retrieveMovies = async () => {
+	const response = await axios.get(`${process.env.REACT_APP_BACKEND_BASE_URL}/api/v1/movies`);
+	return response.data;
+};
+
+const retrieveQualities = async () => {
+	const response = await axios.get(`${process.env.REACT_APP_BACKEND_BASE_URL}/api/v1/qualities`);
+	return response.data;
+};
+
+const submitCreate = async (data) => {
+	return await axios.post(`${process.env.REACT_APP_BACKEND_BASE_URL}/api/v1/sessions`, data);
+};
+
+const submitUpdate = async (data) => {
+	return await axios.put(`${process.env.REACT_APP_BACKEND_BASE_URL}/api/v1/sessions/${data.sessionId}`, data);
+};
+
+export default function AdminSessionModal({ session = null, onClose }) {
+	console.log(session);
+	const { data: cinemasData, isLoading: cinemasIsLoading } = useQuery("cinemas", retrieveCinemas);
+	const {
+		data: cinemaRoomsData,
+		isLoading: cinemaRoomsIsLoading,
+		refetch: cinemaRoomsRefetch,
+	} = useQuery("admin-cinema-rooms", () =>
+		retrieveCinemaRooms({
+			cinemaId: watch("cinemaId") || undefined,
+		})
+	);
+	const { data: moviesData, isLoading: moviesIsLoading } = useQuery("movies", retrieveMovies);
+	const { data: qualitiesData, isLoading: qualitiesIsLoading } = useQuery("qualities", retrieveQualities);
+
+	const create = useMutation({
+		mutationFn: submitCreate,
+	});
+
+	const update = useMutation({
+		mutationFn: submitUpdate,
+	});
+
+	const {
+		register,
+		handleSubmit,
+		formState: { errors },
+		setError,
+		clearErrors,
+		watch,
+	} = useForm({
+		defaultValues: {
+			sessionId: session?.sessionId || null,
+			cinemaId: session?.cinemaId || null,
+			cinemaRoomId: session?.cinemaRoomId || null,
+			movieId: session?.movieId || null,
+			qualityId: session?.qualityId || null,
+			startDate: session?.startDate || null,
+			endDate: session?.endDate || null,
+			standartFreePlaces: session?.standartFreePlaces || null,
+			disabledFreePlaces: session?.disabledFreePlaces || null,
+		},
+	});
+
+	const cinemaId = watch("cinemaId");
+
+	useEffect(() => {
+		cinemaRoomsRefetch();
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [cinemaId]);
+
+	const onSubmit = (data) => {
+		clearErrors();
+
+		if (!session) {
+			create.mutate(data, {
+				onError: () => {
+					setError("form", {
+						message: DEFAULT_UNKNOWN_ERROR,
+					});
+				},
+				onSuccess: (response) => {
+					if (response?.status === 201) {
+						onClose();
+						return;
+					}
+					// Unknown case
+					setError("form", {
+						message: DEFAULT_UNKNOWN_ERROR,
+					});
+				},
+			});
+		} else {
+			update.mutate(data, {
+				onError: () => {
+					setError("form", {
+						message: DEFAULT_UNKNOWN_ERROR,
+					});
+				},
+				onSuccess: (response) => {
+					if (response?.status === 204) {
+						onClose();
+						return;
+					}
+					// Unknown case
+					setError("form", {
+						message: DEFAULT_UNKNOWN_ERROR,
+					});
+				},
+			});
+		}
+	};
+
+	if (cinemasIsLoading || cinemaRoomsIsLoading || moviesIsLoading || qualitiesIsLoading) {
+		return <span>Loading...</span>;
+	}
+
+	return (
+		<Modal onClose={onClose}>
+			<form action="#" method="POST" onSubmit={handleSubmit(onSubmit)}>
+				<div style={{ display: "flex", flexDirection: "column", gap: "20px" }}>
+					<h1>{!session ? "Ajouter une scéance" : "Modifier une scéance"}</h1>
+
+					{errors.form && <p>{errors.form.message}</p>}
+
+					<Box sx={{ minWidth: 250 }}>
+						<FormControl fullWidth>
+							<InputLabel>Cinéma</InputLabel>
+							<Select
+								label="Selectionner le cinéma"
+								defaultValue={watch("cinemaId")}
+								{...register("cinemaId", { required: true })}
+								error={!!errors.cinemaId}
+								helperText={errors.cinemaId?.message}
+							>
+								{cinemasData?.data?.map((cinema) => (
+									<MenuItem key={cinema.cinemaId} value={cinema.cinemaId}>
+										{cinema.cinemaName}
+									</MenuItem>
+								))}
+							</Select>
+						</FormControl>
+					</Box>
+
+					<Box sx={{ minWidth: 250 }}>
+						<FormControl fullWidth>
+							<InputLabel>Numéro de salle</InputLabel>
+							<Select
+								label="Selectionner la salle"
+								defaultValue={watch("cinemaRoomId")}
+								{...register("cinemaRoomId", { required: true })}
+								error={!!errors.cinemaRoomId}
+								helperText={errors.cinemaRoomId?.message}
+							>
+								{cinemaRoomsData?.data?.map((cinemaRoom) => (
+									<MenuItem key={cinemaRoom.cinemaRoomId} value={cinemaRoom.cinemaRoomId}>
+										{cinemaRoom.roomNumber}
+									</MenuItem>
+								))}
+							</Select>
+						</FormControl>
+					</Box>
+
+					<Box sx={{ minWidth: 250 }}>
+						<FormControl fullWidth>
+							<InputLabel>Film</InputLabel>
+							<Select
+								label="Selectionner le film"
+								defaultValue={watch("movieId")}
+								{...register("movieId", { required: true })}
+								error={!!errors.movieId}
+								helperText={errors.movieId?.message}
+							>
+								{moviesData?.data?.map((movie) => (
+									<MenuItem key={movie.movieId} value={movie.movieId}>
+										{movie.title}
+									</MenuItem>
+								))}
+							</Select>
+						</FormControl>
+					</Box>
+
+					<Box sx={{ minWidth: 250 }}>
+						<FormControl fullWidth>
+							<InputLabel>Qualité</InputLabel>
+							<Select
+								label="Selectionner la qualité"
+								defaultValue={watch("qualityId")}
+								{...register("qualityId", { required: true })}
+								error={!!errors.qualityId}
+								helperText={errors.qualityId?.message}
+							>
+								{qualitiesData?.data?.map((quality) => (
+									<MenuItem key={quality.qualityId} value={quality.qualityId}>
+										{quality.qualityName}
+									</MenuItem>
+								))}
+							</Select>
+						</FormControl>
+					</Box>
+
+					<TextField
+						required
+						label="Date et heure de début"
+						type="text"
+						{...register("startDate", { required: true })}
+						error={!!errors.startDate}
+						helperText={errors.startDate?.message}
+						style={{ width: "100%" }}
+					/>
+
+					<TextField
+						required
+						label="Date et heure de fin"
+						type="text"
+						{...register("endDate", { required: true })}
+						error={!!errors.endDate}
+						helperText={errors.endDate?.message}
+						style={{ width: "100%" }}
+					/>
+
+					<TextField
+						required
+						label="Nombre de places standarts"
+						type="number"
+						{...register("standartFreePlaces", { required: true })}
+						error={!!errors.standartFreePlaces}
+						helperText={errors.standartFreePlaces?.message}
+						style={{ width: "100%" }}
+					/>
+
+					<TextField
+						required
+						label="Nombre de places handicapées"
+						type="number"
+						{...register("disabledFreePlaces", { required: true })}
+						error={!!errors.disabledFreePlaces}
+						helperText={errors.disabledFreePlaces?.message}
+						style={{ width: "100%" }}
+					/>
+
+					<div>
+						<Button
+							variant="contained"
+							type="submit"
+							onClick={() => {
+								clearErrors();
+							}}
+						>
+							Valider
+						</Button>
+					</div>
+				</div>
+			</form>
+		</Modal>
+	);
+}

--- a/website/src/components/organisms/AdminSessionModal/index.js
+++ b/website/src/components/organisms/AdminSessionModal/index.js
@@ -1,0 +1,1 @@
+export { default as AdminSessionModal } from "./AdminSessionModal";

--- a/website/src/components/pages/Admin/Admin.jsx
+++ b/website/src/components/pages/Admin/Admin.jsx
@@ -1,6 +1,7 @@
 import { useContext } from "react";
 
 import { AdminMovieList } from "components/organisms/AdminMovieList";
+import { AdminSessionList } from "components/organisms/AdminSessionList";
 import { Page } from "components/templates/Page";
 import { CurrentUserContext } from "components/templates/Page/providers/CurrentUserProvider";
 
@@ -15,6 +16,7 @@ export default function Admin() {
 		<Page>
 			<div style={{ display: "flex", flexDirection: "column", gap: "20px" }}>
 				<AdminMovieList />
+				<AdminSessionList />
 			</div>
 		</Page>
 	);


### PR DESCRIPTION
**Project**: https://wooded-english-733.notion.site/US-8-Espace-Administrateur-f10a44ad83b2488bb0838c495c7efe6c?pvs=74

**Here**
- Create the `GET /api/v1/cinemas/:cinemaId/rooms` endpoint
- Create the `GET /api/v1/qualities` endpoint
- Create the `PUT /api/v1/sessions/:sessionId` endpoint
- Create the `POST /api/v1/sessions` endpoint
- Create the `DELETE /api/v1/sessions/:sessionId` endpoint
- Allow CRUD on sessions trough the admin

**Demo**

![Screenshot 2024-06-26 074941](https://github.com/markomilicevic/studi-ecf/assets/3176231/857e9d92-003a-4df3-bfc6-a93059890676)

![Screenshot 2024-06-26 074952](https://github.com/markomilicevic/studi-ecf/assets/3176231/a526c0b3-cea0-4d5c-a218-213d842dd8d5)
