### PR TITLE
feat(US-8): Show admin analytics

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -5,6 +5,7 @@ import cors from "cors";
 import express from "express";
 import fileUpload from "express-fileupload";
 
+import { loadAnalyticsRoutes } from "./src/Analytics/routes.js";
 import { loadBookingRoutes } from "./src/Booking/routes.js";
 import { loadCinemaRoutes } from "./src/Cinema/routes.js";
 import { loadGenreRoutes } from "./src/Genre/routes.js";
@@ -90,6 +91,7 @@ import { loadUserRoutes } from "./src/User/routes.js";
 		res.status(200).json({ ok: true });
 	});
 
+	loadAnalyticsRoutes(app);
 	loadBookingRoutes(app);
 	loadCinemaRoutes(app);
 	loadGenreRoutes(app);

--- a/backend/src/Analytics/Adapter/ElasticSearch/GetTickets/GetTicketsRepository.js
+++ b/backend/src/Analytics/Adapter/ElasticSearch/GetTickets/GetTicketsRepository.js
@@ -1,0 +1,97 @@
+import { ElasticSearchFactory } from "../../../../Common/Utils/elasticsearch.js";
+
+export default class GetTicketsRepository {
+	async fetch({ startDate, endDate, movieId = null }) {
+		let payload = {
+			index: "tickets",
+			query: {
+				bool: {
+					must: [
+						{
+							range: {
+								bookedAt: {
+									gte: startDate,
+									lte: endDate,
+								},
+							},
+						},
+					],
+				},
+			},
+			aggs: {
+				aggPerMovieId: {
+					multi_terms: {
+						terms: [
+							{
+								field: "bookedAt",
+							},
+							{
+								field: "movieId",
+							},
+						],
+					},
+				},
+			},
+			size: 0, // In order to not return matched `hits`
+		};
+		if (movieId) {
+			payload.query.bool.must.push({ match: { movieId } });
+		}
+		console.log(payload);
+		const search = await ElasticSearchFactory.getInstance().getClient().search(payload);
+
+		if (!search?.aggregations?.aggPerMovieId?.buckets?.length) {
+			// No tickets sold in that period of time
+			return [];
+		}
+
+		/*
+			Example of `search`:
+			```
+			{
+				"took": 3,
+				"timed_out": false,
+				"_shards": {
+					"total": 1,
+					"successful": 1,
+					"skipped": 0,
+					"failed": 0
+				},
+				"hits": {
+					"total": {
+						"value": 5,
+						"relation": "eq"
+					},
+					"max_score": null,
+					"hits": []
+				},
+				"aggregations": {
+					"aggPerMovieId": {
+						"doc_count_error_upper_bound": 0,
+						"sum_other_doc_count": 0,
+						"buckets": [{
+							"key": ["2024-06-08T00:00:00.000Z", "b3efa1f5-7d09-4cc4-a3d2-d0792a667dd1"],
+							"key_as_string": "2024-06-08T00:00:00.000Z|b3efa1f5-7d09-4cc4-a3d2-d0792a667dd1",
+							"doc_count": 2
+						}, {
+							"key": ["2024-06-08T00:00:00.000Z", "b87a3c4e-91f4-415f-9f69-763f3ab71dd9"],
+							"key_as_string": "2024-06-08T00:00:00.000Z|b87a3c4e-91f4-415f-9f69-763f3ab71dd9",
+							"doc_count": 2
+						}, {
+							"key": ["2024-06-05T00:00:00.000Z", "b3efa1f5-7d09-4cc4-a3d2-d0792a667dd1"],
+							"key_as_string": "2024-06-05T00:00:00.000Z|b3efa1f5-7d09-4cc4-a3d2-d0792a667dd1",
+							"doc_count": 1
+						}]
+					}
+				}
+			}
+			```
+		*/
+
+		return search.aggregations.aggPerMovieId.buckets.map((bucket) => ({
+			bookedAt: bucket.key[0],
+			movieId: bucket.key[1],
+			count: bucket.doc_count,
+		}));
+	}
+}

--- a/backend/src/Analytics/Adapter/Http/GetTickets/GetTicketsController.js
+++ b/backend/src/Analytics/Adapter/Http/GetTickets/GetTicketsController.js
@@ -1,0 +1,20 @@
+export default class GetTicketsController {
+	constructor(validator, service) {
+		this.service = service;
+	}
+
+	async handle(query) {
+		if (!query.startDate) {
+			throw new Error("Missing startDate");
+		}
+		if (!query.endDate) {
+			throw new Error("Missing endDate");
+		}
+
+		return await this.service.execute({
+			startDate: query.startDate,
+			endDate: query.endDate,
+			movieId: query.movieId
+		});
+	}
+}

--- a/backend/src/Analytics/Adapter/Sequelize/GetTickets/GetMoviesRepository.js
+++ b/backend/src/Analytics/Adapter/Sequelize/GetTickets/GetMoviesRepository.js
@@ -1,0 +1,23 @@
+import { Op } from "sequelize";
+
+import MovieModel from "../MovieModel.js";
+import Movie from "../../../Business/Movie.js";
+
+export default class GetMoviesRepository {
+	async fetchAll({ movieIds }) {
+		const query = {
+			where: {
+				movieId: { [Op.in]: movieIds },
+			},
+			order: [["title", "ASC"]],
+		};
+		const movies = await MovieModel.findAll(query);
+
+		return movies.map((movie) => {
+			const obj = new Movie();
+			obj.setMovieId(movie.movieId);
+			obj.setTitle(movie.title);
+			return obj;
+		});
+	}
+}

--- a/backend/src/Analytics/Adapter/Sequelize/MovieModel.js
+++ b/backend/src/Analytics/Adapter/Sequelize/MovieModel.js
@@ -1,0 +1,23 @@
+import { DataTypes } from "@sequelize/core";
+
+import { SequelizeFactory } from "../../../Common/Utils/sequelize.js";
+
+export default SequelizeFactory.getInstance()
+	.getSequelize()
+	.define("movie", {
+		movieId: {
+			primaryKey: true,
+			type: DataTypes.UUID,
+		},
+		title: {
+			type: DataTypes.STRING,
+		},
+		createdAt: {
+			type: DataTypes.DATE,
+		},
+		updatedAt: {
+			type: DataTypes.DATE,
+		},
+	}, {
+		paranoid: true
+	});

--- a/backend/src/Analytics/Business/Movie.js
+++ b/backend/src/Analytics/Business/Movie.js
@@ -1,0 +1,41 @@
+export default class Movie {
+	setMovieId(movieId) {
+		this.movieId = movieId;
+	}
+
+	setPosterId(posterId) {
+		this.posterId = posterId;
+	}
+
+	setGenreId(genreId) {
+		this.genreId = genreId;
+	}
+
+	setTitle(title) {
+		this.title = title;
+	}
+
+	setDescription(description) {
+		this.description = description;
+	}
+
+	setMinimalAge(minimalAge) {
+		this.minimalAge = minimalAge;
+	}
+
+	setIsHighlight(isHightlight) {
+		this.isHightlight = isHightlight;
+	}
+
+	setRating(rating) {
+		this.rating = rating;
+	}
+
+	setCreatedAt(createdAt) {
+		this.createdAt = createdAt;
+	}
+
+	setUpdatedAt(updatedAt) {
+		this.updatedAt = updatedAt;
+	}
+}

--- a/backend/src/Analytics/UseCase/GetTickets/GetTicketsService.js
+++ b/backend/src/Analytics/UseCase/GetTickets/GetTicketsService.js
@@ -1,0 +1,85 @@
+import moment from "moment";
+
+import Response from "../../../Common/Utils/Response.js";
+
+export default class GetTicketsService {
+	constructor(ticketsRepository, moviesRepository) {
+		this.ticketsRepository = ticketsRepository;
+		this.moviesRepository = moviesRepository;
+	}
+
+	async execute(query) {
+		const res = new Response();
+
+		if (!query.startDate || !moment(query.startDate).isValid()) {
+			throw new Error("Invalid startDate");
+		}
+		if (!query.endDate || !moment(query.endDate).isValid()) {
+			throw new Error("Invalid endDate");
+		}
+		if (moment(query.startDate).isAfter(moment(query.endDate))) {
+			throw new Error("startDate must be before endDate");
+		}
+
+		let tickets = await this.ticketsRepository.fetch({ startDate: query.startDate, endDate: query.endDate, movieId: query.movieId });
+		if (!tickets?.length) {
+			// No tickets sold in that period of time
+			res.setData([]);
+			return res;
+		}
+
+		// Fetch all movies titles
+		const movieIds = Array.from(new Set(tickets.map((ticket) => ticket.movieId)));
+		const movies = await this.moviesRepository.fetchAll({ movieIds });
+		if (!movies?.length) {
+			throw new Error(`No movie found for movieIds=${JSON.stringify(movieIds)}`);
+		}
+
+		// Associate all movies titles
+		tickets = tickets.map((ticket) => {
+			const movie = movies.find((movie) => movie.movieId === ticket.movieId);
+			if (!movie) {
+				throw new Error(`No movie found for movieId=${ticket.movieId}`);
+			}
+
+			return {
+				...ticket,
+				movieTitle: movie.title,
+			};
+		});
+
+		// Return a Google Chart's friendly response
+
+		const data = [];
+		const uniqBookedAts = Array.from(new Set(tickets.map((ticket) => ticket.bookedAt)));
+		const uniqMovieTitles = Array.from(new Set(movies.map((movie) => movie.title)));
+
+		// Header
+		const header = ["date"];
+		for (let i = 0; i < uniqMovieTitles.length; i++) {
+			header.push(uniqMovieTitles[i]);
+		}
+		data.push(header);
+
+		// Row
+		for (let i = 0; i < uniqBookedAts.length; i++) {
+			const bookedAt = uniqBookedAts[i];
+			const row = [bookedAt];
+			for (let j = 0; j < uniqMovieTitles.length; j++) {
+				const movieTitle = uniqMovieTitles[j];
+				// The same movieTitle can be used by several movieId
+				const count = tickets.reduce((acc, ticket) => {
+					if (ticket.bookedAt === bookedAt && ticket.movieTitle === movieTitle) {
+						return acc + ticket.count;
+					}
+					return acc;
+				}, 0);
+				row.push(count);
+			}
+			data.push(row);
+		}
+
+		res.setData(data);
+		return res;
+	}
+}

--- a/backend/src/Analytics/routes.js
+++ b/backend/src/Analytics/routes.js
@@ -1,0 +1,21 @@
+import GetTicketsRepository from "./Adapter/ElasticSearch/GetTickets/GetTicketsRepository.js";
+import GetTicketsController from "./Adapter/Http/GetTickets/GetTicketsController.js";
+import GetTicketsMoviesRepository from "./Adapter/Sequelize/GetTickets/GetMoviesRepository.js";
+import GetTicketsService from "./UseCase/GetTickets/GetTicketsService.js";
+
+export const loadAnalyticsRoutes = (app) => {
+	app.get("/api/v1/analytics/tickets", async (req, res) => {
+		try {
+			if (!req.me || req.me.role !== "admin") {
+				return res.status(401).json({ error: true });
+			}
+
+			const controller = new GetTicketsController(null, new GetTicketsService(new GetTicketsRepository(), new GetTicketsMoviesRepository()));
+			const response = await controller.handle(req.query);
+			res.status(200).json(response);
+		} catch (err) {
+			console.error(err);
+			res.status(500).json({ error: true });
+		}
+	});
+};

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -21,6 +21,7 @@
 				"notistack": "^3.0.1",
 				"react": "^18.3.1",
 				"react-dom": "^18.3.1",
+				"react-google-charts": "^4.0.1",
 				"react-hook-form": "^7.52.0",
 				"react-query": "^3.39.3",
 				"react-router-dom": "^6.23.1",
@@ -24404,6 +24405,15 @@
 			"version": "6.0.11",
 			"resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.11.tgz",
 			"integrity": "sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg=="
+		},
+		"node_modules/react-google-charts": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/react-google-charts/-/react-google-charts-4.0.1.tgz",
+			"integrity": "sha512-V/hcMcNuBgD5w49BYTUDye+bUKaPmsU5vy/9W/Nj2xEeGn+6/AuH9IvBkbDcNBsY00cV9OeexdmgfI5RFHgsXQ==",
+			"peerDependencies": {
+				"react": ">=16.3.0",
+				"react-dom": ">=16.3.0"
+			}
 		},
 		"node_modules/react-hook-form": {
 			"version": "7.52.0",

--- a/website/package.json
+++ b/website/package.json
@@ -16,6 +16,7 @@
 		"notistack": "^3.0.1",
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",
+		"react-google-charts": "^4.0.1",
 		"react-hook-form": "^7.52.0",
 		"react-query": "^3.39.3",
 		"react-router-dom": "^6.23.1",

--- a/website/src/components/molecules/Chart/Chart.jsx
+++ b/website/src/components/molecules/Chart/Chart.jsx
@@ -1,0 +1,25 @@
+import { Chart as ReactGoogleChart } from "react-google-charts";
+
+export default function Chart({ data, width, height }) {
+	const formattedData =
+		data?.map((row, index) => {
+			if (index === 0) {
+				const header = [{ type: "date", label: "Jour" }];
+				for (let i = 1; i < row.length; i++) {
+					header.push({ type: "number", label: row[i] });
+				}
+				return header;
+			} else {
+				// Requiring Date object
+				row[0] = new Date(row[0]);
+				return row;
+			}
+		}) || [];
+	const options = {
+		legend: { position: "bottom" },
+		hAxis: {
+			format: "dd-MM-yyyy",
+		},
+	};
+	return <ReactGoogleChart chartType="ColumnChart" width={width} height={height} data={formattedData} options={options} />;
+}

--- a/website/src/components/molecules/Chart/index.js
+++ b/website/src/components/molecules/Chart/index.js
@@ -1,0 +1,1 @@
+export { default as Chart } from "./Chart";

--- a/website/src/components/organisms/AdminNav/AdminNav.jsx
+++ b/website/src/components/organisms/AdminNav/AdminNav.jsx
@@ -1,0 +1,19 @@
+import { Box } from "@mui/material";
+import { NavLink } from "react-router-dom";
+
+export default function AdminNav() {
+	return (
+		<Box sx={{ display: "flex", justifyContent: "center" }}>
+			<nav>
+				<ul style={{ display: "flex", flexDirection: "row", gap: 20 }}>
+					<li>
+						<NavLink to="/admin">Gestion</NavLink>
+					</li>
+					<li>
+						<NavLink to="/admin/analytics">Analytics</NavLink>
+					</li>
+				</ul>
+			</nav>
+		</Box>
+	);
+}

--- a/website/src/components/organisms/AdminNav/index.js
+++ b/website/src/components/organisms/AdminNav/index.js
@@ -1,0 +1,1 @@
+export { default as AdminNav } from "./AdminNav";

--- a/website/src/components/organisms/AdminTicketsChart/AdminTicketsChart.jsx
+++ b/website/src/components/organisms/AdminTicketsChart/AdminTicketsChart.jsx
@@ -1,0 +1,87 @@
+import axios from "axios";
+import moment from "moment";
+import { useEffect, useState } from "react";
+import { useQuery } from "react-query";
+
+import { Chart } from "components/molecules/Chart";
+import { DayRangePicker } from "components/organisms/DayRangePicker";
+import { MovieListDropdown } from "components/organisms/MovieListDropdown";
+
+const retrieveMovies = async () => {
+	const response = await axios.get(`${process.env.REACT_APP_BACKEND_BASE_URL}/api/v1/movies`);
+	return response.data;
+};
+
+const retrieveMetrics = async ({ startDate, endDate, movieId = null }) => {
+	const response = await axios.get(`${process.env.REACT_APP_BACKEND_BASE_URL}/api/v1/analytics/tickets`, {
+		params: {
+			startDate: new moment(startDate).format("YYYY-MM-DD"),
+			endDate: new moment(endDate).format("YYYY-MM-DD"),
+			movieId,
+		},
+	});
+	return response.data;
+};
+
+export default function AdminTicketsChart() {
+	const currentDate = new Date();
+	const [filters, setFilters] = useState({
+		defaultDatesChanged: false,
+		startDate: moment(currentDate).subtract(7, "d"),
+		endDate: moment(currentDate),
+		movie: null,
+	});
+
+	const { data: moviesData, error: moviesError, isLoading: moviesIsLoading } = useQuery("movies", retrieveMovies);
+
+	const {
+		data: metricsData,
+		error: metricsError,
+		isLoading: metricsIsLoading,
+		refetch: metricsRefetch,
+	} = useQuery("admin-analytics-metrics", () =>
+		retrieveMetrics({
+			startDate: filters.startDate,
+			endDate: filters.endDate,
+			movieId: filters.movie?.movieId || undefined,
+		})
+	);
+
+	useEffect(() => {
+		if (metricsData?.data) {
+			metricsRefetch();
+		}
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [filters]);
+
+	if (metricsIsLoading) {
+		return <div>...</div>;
+	}
+	if (metricsError) {
+		return <div>Une erreur est survenue</div>;
+	}
+
+	return (
+		<div>
+			<h1>
+				{!filters.defaultDatesChanged ? "Ventes de tickets par film sur les 7 derniers jours" : "Ventes de tickets par jour et par film avec filtres"}
+			</h1>
+			<div style={{ display: "flex", flexDirection: "column", gap: "20px", marginTop: "20px", marginBottom: "20px" }}>
+				<DayRangePicker
+					startDate={filters.startDate}
+					endDate={filters.endDate}
+					setStartDate={(newStartDate) => setFilters({ ...filters, startDate: newStartDate, defaultDatesChanged: true })}
+					setEndDate={(newEndDate) => setFilters({ ...filters, endDate: newEndDate, defaultDatesChanged: true })}
+				/>
+				<MovieListDropdown
+					data={moviesData?.data}
+					error={moviesError}
+					isLoading={moviesIsLoading}
+					movie={filters.movie}
+					setMovie={(newMovie) => setFilters({ ...filters, movie: newMovie, defaultDatesChanged: true })}
+				/>
+			</div>
+			{metricsData?.data?.length ? <Chart data={metricsData.data} width="100%" height="50vh" /> : <div>Aucune donnée</div>}
+		</div>
+	);
+}

--- a/website/src/components/organisms/AdminTicketsChart/index.js
+++ b/website/src/components/organisms/AdminTicketsChart/index.js
@@ -1,0 +1,1 @@
+export { default as AdminTicketsChart } from "./AdminTicketsChart";

--- a/website/src/components/organisms/DayRangePicker/DayRangePicker.jsx
+++ b/website/src/components/organisms/DayRangePicker/DayRangePicker.jsx
@@ -1,0 +1,22 @@
+import React from "react";
+import { AdapterMoment } from "@mui/x-date-pickers/AdapterMoment";
+import { LocalizationProvider } from "@mui/x-date-pickers/LocalizationProvider";
+import { DatePicker } from "@mui/x-date-pickers/DatePicker";
+
+export default function DayRangePicker({ startDate, endDate, setStartDate, setEndDate }) {
+	return (
+		<div style={{display: 'flex', alignItems: 'center', gap: '10px'}}>
+			<span>Choisir une période :</span>
+
+			Du 
+			<LocalizationProvider dateAdapter={AdapterMoment}>
+				<DatePicker value={startDate} onChange={(newStartDate) => setStartDate(newStartDate)} />
+			</LocalizationProvider>
+
+			Au
+			<LocalizationProvider dateAdapter={AdapterMoment}>
+				<DatePicker value={endDate} onChange={(newEndDate) => setEndDate(newEndDate)} />
+			</LocalizationProvider>
+		</div>
+	);
+}

--- a/website/src/components/organisms/DayRangePicker/index.js
+++ b/website/src/components/organisms/DayRangePicker/index.js
@@ -1,0 +1,1 @@
+export { default as DayRangePicker } from "./DayRangePicker";

--- a/website/src/components/pages/AdminAnalytics/AdminAnalytics.jsx
+++ b/website/src/components/pages/AdminAnalytics/AdminAnalytics.jsx
@@ -1,12 +1,11 @@
 import { useContext } from "react";
 
-import { AdminMovieList } from "components/organisms/AdminMovieList";
 import { AdminNav } from "components/organisms/AdminNav";
-import { AdminSessionList } from "components/organisms/AdminSessionList";
+import { AdminTicketsChart } from "components/organisms/AdminTicketsChart";
 import { Page } from "components/templates/Page";
 import { CurrentUserContext } from "components/templates/Page/providers/CurrentUserProvider";
 
-export default function Admin() {
+export default function AdminAnalytics() {
 	const { isConnected, data: userData } = useContext(CurrentUserContext);
 
 	if (!isConnected || (userData?.data?.role && userData.data.role !== "admin")) {
@@ -17,10 +16,7 @@ export default function Admin() {
 		<Page>
 			<AdminNav />
 			<hr />
-			<div style={{ display: "flex", flexDirection: "column", gap: "20px" }}>
-				<AdminMovieList />
-				<AdminSessionList />
-			</div>
+			<AdminTicketsChart />
 		</Page>
 	);
 }

--- a/website/src/components/pages/AdminAnalytics/index.jsx
+++ b/website/src/components/pages/AdminAnalytics/index.jsx
@@ -1,0 +1,1 @@
+export { default as AdminAnalytics } from "./AdminAnalytics";

--- a/website/src/index.js
+++ b/website/src/index.js
@@ -11,6 +11,7 @@ import { RouterProvider, createBrowserRouter } from "react-router-dom";
 
 import { Account } from "components/pages/Account";
 import { Admin } from "components/pages/Admin";
+import { AdminAnalytics } from "components/pages/AdminAnalytics";
 import { Booking } from "components/pages/Booking";
 import { Contact } from "components/pages/Contact";
 import { HomePage } from "components/pages/HomePage";
@@ -61,6 +62,10 @@ const router = createBrowserRouter([
 	{
 		path: "/admin",
 		element: <Admin />,
+	},
+	{
+		path: "/admin/analytics",
+		element: <AdminAnalytics />,
 	},
 ]);
 


### PR DESCRIPTION
**Project**: https://wooded-english-733.notion.site/US-8-Espace-Administrateur-f10a44ad83b2488bb0838c495c7efe6c?pvs=74

**Here**
- Create the `GET /api/v1/analytics/tickets` endpoint
- Display and filter analytics on the admin

**Demo**

![Screenshot 2024-06-26 080454](https://github.com/markomilicevic/studi-ecf/assets/3176231/ce467d7b-27b3-41f1-b515-04a3bdb847ce)