### PR TITLE
fix: Set the right price based on quality and country

### DIFF
--- a/backend/src/Booking/Adapter/Sequelize/BookingValidator/BookingValidatorSessionRepository.js
+++ b/backend/src/Booking/Adapter/Sequelize/BookingValidator/BookingValidatorSessionRepository.js
@@ -31,6 +31,8 @@ export default class BookingValidatorSessionRepository {
 
 		const obj = new Session();
 		obj.setSessionId(session.sessionId);
+		obj.setQualityId(session.qualityId);
+		obj.setCinemaId(session.cinemas_rooms.cinemaId);
 		obj.setStartDate(session.startDate);
 		obj.setEndDate(session.endDate);
 		obj.setCinemaRoom(cr);


### PR DESCRIPTION
**Context**

- The price is now displayed for each session (from https://github.com/markomilicevic/studi-ecf/pull/32 )
- The user is booking

**Problem**

The proposed price is incorrect

![Screenshot 2024-06-30 113910](https://github.com/markomilicevic/studi-ecf/assets/3176231/d57c747d-11d1-47af-b763-4aaa82962853)

**Cause**

The proposed price is not based on the quality & country

**Root cause**

The problem is discovered just now because we're started to display the price for each session (from https://github.com/markomilicevic/studi-ecf/pull/32 )

**Here**

Fix the price computation by giving the right quality & country (trough the cinema)

**Demo**

After:

![Screenshot 2024-06-30 113758](https://github.com/markomilicevic/studi-ecf/assets/3176231/b8d0a2fb-b59a-4237-b79c-fa0e96fa7634)