### PR TITLE
fix: Set the right incidents display

### DIFF
--- a/desktop/src/components/organisms/IncidentList/IncidentList.jsx
+++ b/desktop/src/components/organisms/IncidentList/IncidentList.jsx
@@ -113,14 +113,23 @@ export default function IncidentList() {
 				cinemasError={cinemasError}
 				cinemasIsLoading={cinemasIsLoading}
 				countryCode={countryCode}
-				setCountryCode={setCountryCode}
+				setCountryCode={(countryCode) => {
+					setCountryCode(countryCode);
+					cinemaRoomIncidentsRefetch();
+				}}
 				cinema={cinema}
-				setCinema={setCinema}
+				setCinema={(cinema) => {
+					setCinema(cinema);
+					cinemaRoomIncidentsRefetch();
+				}}
 				cinemaRoomsData={cinemaRoomsData?.data}
 				cinemaRoomsError={cinemaRoomsError}
 				cinemaRoomsIsLoading={cinemaRoomsIsLoading}
 				cinemaRoom={cinemaRoom}
-				setCinemaRoom={setCinemaRoom}
+				setCinemaRoom={(cinemaRoom) => {
+					setCinemaRoom(cinemaRoom);
+					cinemaRoomIncidentsRefetch();
+				}}
 			/>
 
 			<div style={{ display: "flex", justifyContent: "end", paddingTop: 20 }}>
@@ -161,7 +170,9 @@ export default function IncidentList() {
 											{incident.roomNumber}
 										</StyledTableCell>
 										<StyledTableCell component="th" scope="row">
-											<pre>{incident.incident}</pre>
+											{incident.incident?.split("\n").map((line, index) => (
+												<p key={index}>{line}</p>
+											))}
 										</StyledTableCell>
 										<StyledTableCell component="th" scope="row">
 											{moment(incident.lastModifiedAt).format("LLL")}
@@ -229,7 +240,6 @@ export default function IncidentList() {
 							setIncidentModalOpened(false);
 							setSelectedIncident(null);
 							cinemaRoomIncidentsRefetch();
-							enqueueSnackbar("Incident ajouté/mis à jour");
 						}}
 					/>
 				)}

--- a/desktop/src/components/organisms/IncidentModal/IncidentModal.jsx
+++ b/desktop/src/components/organisms/IncidentModal/IncidentModal.jsx
@@ -67,8 +67,8 @@ export default function IncidentModal({
 	} = useForm({
 		defaultValues: {
 			cinemaRoomIncidentId: incident?.cinemaRoomIncidentId || null,
-			cinemaId: incident?.cinemaId || null,
-			cinemaRoomId: incident?.cinemaRoomId || null,
+			cinemaId: incident?.cinemaId || cinema?.cinemaId || null,
+			cinemaRoomId: incident?.cinemaRoomId || cinemaRoom?.cinemaRoomId || null,
 			incident: incident?.incident || "",
 		},
 	});
@@ -77,7 +77,7 @@ export default function IncidentModal({
 
 	const { data: cinemaRoomIncidentData, refetch: cinemaRoomIncidentRefetch } = useQuery(`cinemas-room-incident-${cinemaRoomId}`, () =>
 		retrieveCinemaRoomIncident({
-			cinemaRoomId: !incident ? cinemaRoomId : undefined,
+			cinemaRoomId: !incident ? cinemaRoom?.cinemaRoomId : undefined,
 		})
 	);
 


### PR DESCRIPTION
**Context**

An employee is using the incident tool

**Problems**

- The incident text is taking a too long line
- The refresh of incidents is not taken in account when country or cinema changed

**Here**

- The incident text is now in several lines
- The incidents are now refreshed when country or cinema changed