### PR TITLE
feat: Automatic letsencrypt renewals

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,6 +107,8 @@ install-prod:
 	crontab -l > mycron || true
 	# Echo new cron
 	echo "0 0 * * * sudo reboot" >> mycron
+	# Renew Letsencrypt certificates every 1st day of months
+	echo "0 0 1 * * sudo docker-compose -f /home/markomilicevicfr/prod/docker-compose-prod.yml run certbot renew" >> mycron
 	# Install new cron file
 	crontab mycron
 	# Cleanup

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -38,6 +38,8 @@ services:
             - ./static/:/var/www/static
             - ./http/nginx.conf:/etc/nginx/nginx.conf
             - ./certbot/conf/:/etc/nginx/ssl
+            # Certbot will put files here for the ACME challenge
+            - ./certbot/www/:/var/www/certbot
         ports:
             - "80:80"
             - "443:443"


### PR DESCRIPTION
**Context**

The Letsencrypt certificates used for the HTTPS web server is expiring soon (**3 months validity**):
 
![Screenshot 2024-08-30 191641](https://github.com/user-attachments/assets/435edde3-fd52-4452-9302-97a66e25e6d6)

**Problem**

The web site will be unavailable (invalid certificates browser's error) for the users if the certificate expired

**Here**

As recommended [by Letsencrypt](https://letsencrypt.org/2015/11/09/why-90-days), the best practice is to implement automatic renewals, here is this implementation

**Demo**

After renewal:

![Screenshot 2024-08-30 202204](https://github.com/user-attachments/assets/bfb4e8ba-180e-4758-9c0b-f3a2cd760080)